### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/documentation/modflow/index.rst
+++ b/documentation/modflow/index.rst
@@ -10,7 +10,7 @@ The PCRaster Modflow extension enables a modeller to embed groundwater flow calu
 
 .. |schmitz2009| raw:: html
 
-   <a href="http://dx.doi.org/10.1016/j.envsoft.2009.02.018" target="_blank">Schmitz et al, 2009</a>
+   <a href="https://doi.org/10.1016/j.envsoft.2009.02.018" target="_blank">Schmitz et al, 2009</a>
 
 
 ..

--- a/documentation/modflow/introduction.rst
+++ b/documentation/modflow/introduction.rst
@@ -9,4 +9,4 @@ The PCRaster Modflow extension enables a modeller to embed groundwater flow calu
 
 .. |schmitz2009| raw:: html
 
-   <a href="http://dx.doi.org/10.1016/j.envsoft.2009.02.018" target="_blank">Schmitz et al, 2009</a>
+   <a href="https://doi.org/10.1016/j.envsoft.2009.02.018" target="_blank">Schmitz et al, 2009</a>

--- a/source/pcraster_model_engine/linkInDocsMain
+++ b/source/pcraster_model_engine/linkInDocsMain
@@ -46,7 +46,7 @@ The API enables programmers to write a shared library
 in their preferred programming language and expose the
 functionality to the PCRaster model engine (pcrcalc or PCRasterPython).
 Functionality can be exposed as simple (stateless) functions with a number of input and output arguments or statefull objects with methods changing the object state. State full objects allows to link your model script with:
- - other complex pieces of software such as other models (See Linking external components to a spatio-temporal modelling framework: Coupling MODFLOW and PCRaster: http://dx.doi.org/10.1016/j.envsoft.2009.02.018).
+ - other complex pieces of software such as other models (See Linking external components to a spatio-temporal modelling framework: Coupling MODFLOW and PCRaster: https://doi.org/10.1016/j.envsoft.2009.02.018).
  - use your own data structures beyond raster maps and nonspatials inside the object.
 
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!