### PR TITLE
cmake: remove use of configure_python_extension

### DIFF
--- a/source/mldd/python/CMakeLists.txt
+++ b/source/mldd/python/CMakeLists.txt
@@ -13,10 +13,6 @@ target_link_libraries(_pcraster_mldd_python
         $<IF:$<CXX_COMPILER_ID:GNU>,Python::Python,Python::Module>
 )
 
-configure_python_extension(_pcraster_mldd_python
-    "_pcraster_mldd"
-)
-
 set_target_properties(_pcraster_mldd_python
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY

--- a/source/modflow/python/CMakeLists.txt
+++ b/source/modflow/python/CMakeLists.txt
@@ -56,10 +56,6 @@ add_dependencies(_pcraster_modflow_python
     pcraster_modflow
 )
 
-# configure_python_extension(_pcraster_modflow_python
-#     "_pcraster_modflow"
-# )
-
 set_target_properties(_pcraster_modflow_python
     PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY  "$<TARGET_FILE_DIR:pcrcalc>/pcraster"

--- a/source/pcraster_block_python/CMakeLists.txt
+++ b/source/pcraster_block_python/CMakeLists.txt
@@ -44,10 +44,6 @@ set_target_properties(_pcraster_block_python
         DEBUG_POSTFIX ""
 )
 
-# configure_python_extension(_pcraster_block_python
-#     "_pcraster_block_python"
-# )
-
 set(_TARGET_BIN ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})
 
 

--- a/source/pcraster_moc/python/CMakeLists.txt
+++ b/source/pcraster_moc/python/CMakeLists.txt
@@ -25,10 +25,6 @@ else()
     )
 endif()
 
-configure_python_extension(_pcraster_moc_python
-    "_pcraster_moc"
-)
-
 set_target_properties(_pcraster_moc_python
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY

--- a/source/pcraster_multicore/python/CMakeLists.txt
+++ b/source/pcraster_multicore/python/CMakeLists.txt
@@ -96,10 +96,6 @@ target_include_directories(_pcraster_multicore
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
 )
 
-# configure_python_extension(_pcraster_multicore
-#     "_pcraster_multicore"
-# )
-
 # TODO why is Python::module not working on Linux?
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(_pcraster_multicore

--- a/source/pcraster_python/CMakeLists.txt
+++ b/source/pcraster_python/CMakeLists.txt
@@ -126,10 +126,6 @@ set_target_properties(_pcraster
         DEBUG_POSTFIX ""
 )
 
-# configure_python_extension(_pcraster
-#     "_pcraster"
-# )
-
 #set(_TARGET_BIN ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})
 
 set_target_properties(_pcraster


### PR DESCRIPTION
Calling the CMake command `configure_python_extension` can cause configuration failure, due to the fact that the command doesn't exist.

The use of configure_python_extension and commented-out code using it is removed.

Closes https://github.com/pcraster/pcraster/issues/384